### PR TITLE
Use dynamic import to import plotlyjs.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,4 +2,10 @@
 
 module.exports = {
   name: require('./package').name,
+
+  options: {
+    babel: {
+      plugins: [ require('ember-auto-import/babel-plugin') ]
+    },
+  },
 };


### PR DESCRIPTION
This greatly reduces initial footprint.

It does break tests, however. I am not sure how to fix this properly. An ugly solution is to timeout after every `await render`, in order to ensure that the dynamic import did load:

```javascript
const sleep = m => new Promise(r => setTimeout(r, m));

// …

await render(hbs`{{plot-ly}}`);
await sleep(100);

assert.equal(something);
```

I could add another commit with this, if this approach is fine with you.