### PR TITLE
Fix for Mass upgrade dependencies #177

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -8,7 +8,8 @@ module.exports = function(defaults) {
     autoImport: {
       webpack: {
         node: {
-          global: true
+          global: true,
+          fs: 'empty'
         }
       }
     }


### PR DESCRIPTION
Fixes the bug introduced in this PR: https://github.com/EmberMN/ember-cli-plotly/pull/177

Workaround found here: https://github.com/webpack-contrib/css-loader/issues/447#issuecomment-285603267

Hi! o/ I'm part of the team @Gamma169 mentioned in [this](https://github.com/EmberMN/ember-cli-plotly/issues/176) issue. All of the tests pass on my end with this fix and the above PR.

One additional change I made was removing `"ember-auto-import": "^1.7.0",` from `devDependencies` and updating `ember-auto-import`to `^1.7.0` in `dependencies`. I tried swapping them around (i.e. removed from `dependencies` and kept `devDependencies`) but got errors. I wasn't sure how to make a PR based on an open one so I resorted to commenting here.